### PR TITLE
Add tests cmake functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+/cmake*

--- a/test_build_functions/CMakeLists.Txt
+++ b/test_build_functions/CMakeLists.Txt
@@ -1,0 +1,308 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+function(c_windows_tests_add_dll whatIsBuilding folder)
+    link_directories(${whatIsBuilding}_dll $ENV{VCInstallDir}UnitTest/lib)
+
+    add_library(${whatIsBuilding}_testsonly_lib STATIC
+            ${${whatIsBuilding}_test_files}
+    )
+    SET(VAR 1)
+    foreach(file ${${whatIsBuilding}_test_files})
+        set_source_files_properties(${file} PROPERTIES COMPILE_FLAGS -DCPPUNITTEST_SYMBOL=some_symbol_for_cppunittest_${VAR})
+        MATH(EXPR VAR "${VAR}+1")
+    endforeach()
+
+    set_target_properties(${whatIsBuilding}_testsonly_lib
+               PROPERTIES
+               FOLDER ${folder} )
+
+    target_include_directories(${whatIsBuilding}_testsonly_lib PUBLIC ${sharedutil_include_directories} $ENV{VCInstallDir}UnitTest/include)
+    target_compile_definitions(${whatIsBuilding}_testsonly_lib PUBLIC -DCPP_UNITTEST)
+    target_compile_options(${whatIsBuilding}_testsonly_lib PUBLIC /TP /EHsc)
+
+    add_library(${whatIsBuilding}_dll SHARED
+        ${${whatIsBuilding}_cpp_files}
+        ${${whatIsBuilding}_h_files}
+        ${${whatIsBuilding}_c_files}
+        ${logging_files}
+    )
+
+    set_target_properties(${whatIsBuilding}_dll
+               PROPERTIES
+               FOLDER ${folder})
+
+    set_source_files_properties(${${whatIsBuilding}_c_files} ${logging_files}
+               PROPERTIES
+               COMPILE_FLAGS /TC)
+
+    set_source_files_properties(${${whatIsBuilding}_cpp_files}
+               PROPERTIES
+               COMPILE_FLAGS /TP)
+
+    if (TARGET umock_c)
+        target_link_libraries(${whatIsBuilding}_dll umock_c)
+    endif()
+    if (TARGET ctest)
+        target_link_libraries(${whatIsBuilding}_dll ctest)
+    endif()
+    if (TARGET testrunnerswitcher)
+        target_link_libraries(${whatIsBuilding}_dll testrunnerswitcher)
+    endif()
+
+    target_link_libraries(${whatIsBuilding}_dll ${whatIsBuilding}_testsonly_lib )
+
+    set(PARSING_ADDITIONAL_LIBS OFF)
+    set(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+    set(VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER)
+    set(ARG_PREFIX "none")
+    foreach(f ${ARGN})
+        set(skip_to_next FALSE)
+        if(${f} STREQUAL "ADDITIONAL_LIBS")
+            SET(PARSING_ADDITIONAL_LIBS ON)
+            SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+            set(ARG_PREFIX "none")
+            #also unset all the other states
+            set(skip_to_next TRUE)
+        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+            SET(PARSING_ADDITIONAL_LIBS OFF)
+            SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+            set(skip_to_next TRUE)
+        endif()
+
+        if(NOT skip_to_next)
+            if(PARSING_ADDITIONAL_LIBS)
+                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
+                    SET(ARG_PREFIX ${f})
+                else()
+                    target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_dll ${f})
+                    target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_testsonly_lib ${f})
+                    set(ARG_PREFIX "none")
+                endif()
+            endif()
+        endif()
+
+    endforeach()
+
+    SET(SPACES " ")
+    SET(VAR 1)
+    foreach(file ${${whatIsBuilding}_test_files})
+        # for x64 the underscore is not needed
+        if (ARCHITECTURE STREQUAL "x86_64" OR ARCHITECTURE STREQUAL "ARM")
+            set_property(TARGET ${whatIsBuilding}_dll APPEND_STRING PROPERTY LINK_FLAGS ${SPACES}/INCLUDE:"some_symbol_for_cppunittest_${VAR}")
+        else()
+            set_property(TARGET ${whatIsBuilding}_dll APPEND_STRING PROPERTY LINK_FLAGS ${SPACES}/INCLUDE:"_some_symbol_for_cppunittest_${VAR}")
+        endif()
+        MATH(EXPR VAR "${VAR}+1")
+    endforeach()
+endfunction()
+
+function(c_windows_tests_add_exe whatIsBuilding folder)
+    add_executable(${whatIsBuilding}_exe
+        ${${whatIsBuilding}_test_files}
+        ${${whatIsBuilding}_cpp_files}
+        ${${whatIsBuilding}_h_files}
+        ${${whatIsBuilding}_c_files}
+        ${CMAKE_CURRENT_LIST_DIR}/main.c
+        ${logging_files}
+    )
+    set_target_properties(${whatIsBuilding}_exe
+               PROPERTIES
+               FOLDER ${folder})
+
+    target_compile_definitions(${whatIsBuilding}_exe PUBLIC -DUSE_CTEST)
+    target_include_directories(${whatIsBuilding}_exe PUBLIC ${sharedutil_include_directories})
+    if (TARGET umock_c)
+        target_link_libraries(${whatIsBuilding}_exe umock_c)
+    endif()
+    if (TARGET ctest)
+        target_link_libraries(${whatIsBuilding}_exe ctest)
+    endif()
+    if (TARGET testrunnerswitcher)
+        target_link_libraries(${whatIsBuilding}_exe testrunnerswitcher)
+    endif()
+
+    set(PARSING_ADDITIONAL_LIBS OFF)
+    set(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+    set(VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER)
+    set(ARG_PREFIX "none")
+    foreach(f ${ARGN})
+        set(skip_to_next FALSE)
+        if(${f} STREQUAL "ADDITIONAL_LIBS")
+            SET(PARSING_ADDITIONAL_LIBS ON)
+            SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+            set(ARG_PREFIX "none")
+            #also unset all the other states
+            set(skip_to_next TRUE)
+        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+            SET(PARSING_ADDITIONAL_LIBS OFF)
+            SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+            set(skip_to_next TRUE)
+        endif()
+
+        if(NOT skip_to_next)
+            if(PARSING_ADDITIONAL_LIBS)
+                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
+                    SET(ARG_PREFIX ${f})
+                else()
+                    target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_exe ${f})
+                    set(ARG_PREFIX "none")
+                endif()
+            endif()
+        endif()
+
+    endforeach()
+
+    add_test(NAME ${whatIsBuilding} COMMAND ${whatIsBuilding}_exe)
+endfunction()
+
+#this function takes more than the 1 mandatory argument (whatIsBuilding)
+#the parameters are separated by "known" separators
+#for example, ADDITIONAL_LIBS starts a list of needed libraries
+function(c_linux_tests_add_exe whatIsBuilding folder)
+
+    add_executable(${whatIsBuilding}_exe
+        ${${whatIsBuilding}_test_files}
+        ${${whatIsBuilding}_cpp_files}
+        ${${whatIsBuilding}_h_files}
+        ${${whatIsBuilding}_c_files}
+        ${CMAKE_CURRENT_LIST_DIR}/main.c
+        ${logging_files}
+    )
+    set_target_properties(${whatIsBuilding}_exe
+               PROPERTIES
+               FOLDER ${folder})
+
+    target_compile_definitions(${whatIsBuilding}_exe PUBLIC -DUSE_CTEST)
+    target_include_directories(${whatIsBuilding}_exe PUBLIC ${sharedutil_include_directories})
+
+    #this part detects
+    #       - the additional libraries that might be needed.
+    #     additional libraries are started by ADDITIONAL_LIBS parameter and ended by any other known parameter (or end of variable arguments)
+    #   - a valgrind suppression file (VALGRIND_SUPPRESSIONS_FILE) for memcheck
+    #     the file name follows immediately after
+
+    set(PARSING_ADDITIONAL_LIBS OFF)
+    set(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+    set(VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER)
+    set(ARG_PREFIX "none")
+    foreach(f ${ARGN})
+        set(skip_to_next FALSE)
+        if(${f} STREQUAL "ADDITIONAL_LIBS")
+            SET(PARSING_ADDITIONAL_LIBS ON)
+            SET(PARSING_VALGRIND_SUPPRESSIONS_FILE OFF)
+            set(ARG_PREFIX "none")
+            #also unset all the other states
+            set(skip_to_next TRUE)
+        elseif(${f} STREQUAL "VALGRIND_SUPPRESSIONS_FILE")
+            SET(PARSING_ADDITIONAL_LIBS OFF)
+            SET(PARSING_VALGRIND_SUPPRESSIONS_FILE ON)
+            set(skip_to_next TRUE)
+        endif()
+
+        if(NOT skip_to_next)
+            if(PARSING_ADDITIONAL_LIBS)
+                if((${f} STREQUAL "debug") OR (${f} STREQUAL "optimized") OR (${f} STREQUAL "general"))
+                    SET(ARG_PREFIX ${f})
+                else()
+                    target_link_libraries_with_arg_prefix(${ARG_PREFIX} ${whatIsBuilding}_exe ${f})
+                    set(ARG_PREFIX "none")
+                endif()
+            elseif(PARSING_VALGRIND_SUPPRESSIONS_FILE)
+                set(VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER "--suppressions=${f}")
+            endif()
+        endif()
+
+    endforeach()
+
+    if (TARGET umock_c)
+        target_link_libraries(${whatIsBuilding}_exe umock_c)
+    endif()
+    if (TARGET ctest)
+        target_link_libraries(${whatIsBuilding}_exe ctest)
+    endif()
+    if (TARGET testrunnerswitcher)
+        target_link_libraries(${whatIsBuilding}_exe testrunnerswitcher)
+    endif()
+    target_link_libraries(${whatIsBuilding}_exe umock_c ctest m)
+
+    add_test(NAME ${whatIsBuilding} COMMAND $<TARGET_FILE:${whatIsBuilding}_exe>)
+
+    if(${run_valgrind})
+        find_program(VALGRIND_FOUND NAMES valgrind)
+        if(${VALGRIND_FOUND} STREQUAL VALGRIND_FOUND-NOTFOUND)
+            message(WARNING "run_valgrind was TRUE, but valgrind was not found - there will be no tests run under valgrind")
+        else()
+            add_test(NAME ${whatIsBuilding}_valgrind COMMAND valgrind                 --gen-suppressions=all --num-callers=100 --error-exitcode=1 --leak-check=full --track-origins=yes ${VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER} $<TARGET_FILE:${whatIsBuilding}_exe>)
+            add_test(NAME ${whatIsBuilding}_helgrind COMMAND valgrind --tool=helgrind --gen-suppressions=all --num-callers=100 --error-exitcode=1 ${VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER} $<TARGET_FILE:${whatIsBuilding}_exe>)
+            add_test(NAME ${whatIsBuilding}_drd      COMMAND valgrind --tool=drd      --gen-suppressions=all --num-callers=100 --error-exitcode=1 ${VALGRIND_SUPPRESSIONS_FILE_EXTRA_PARAMETER} $<TARGET_FILE:${whatIsBuilding}_exe>)
+        endif()
+    endif()
+endfunction()
+
+function(build_c_tests whatIsBuilding use_gballoc folder)
+
+    #the first argument is what is building
+    #the second argument is whether the tests should be build with gballoc #defines or not
+    #the following arguments are a list of libraries to link with
+
+    if(${use_gballoc})
+        add_definitions(-DGB_MEASURE_MEMORY_FOR_THIS -DGB_DEBUG_ALLOC)
+    else()
+    endif()
+
+    #setting #defines
+    if(WIN32)
+        add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    else()
+    endif()
+
+    #setting includes
+    set(sharedutil_include_directories ${sharedutil_include_directories} ${TESTRUNNERSWITCHER_INCLUDES} ${CTEST_INCLUDES} ${UMOCK_C_INCLUDES} ${AZURE_C_SHARED_UTILITY_INCLUDES})
+    set(sharedutil_include_directories ${sharedutil_include_directories} ${MICROMOCK_INC_FOLDER} ${UMOCK_C_INC_FOLDER} ${TESTRUNNERSWITCHER_INC_FOLDER} ${CTEST_INC_FOLDER} ${SAL_INC_FOLDER} ${SHARED_UTIL_INC_FOLDER} ${SHARED_UTIL_SRC_FOLDER})
+    if(WIN32)
+    else()
+        include_directories(${sharedutil_include_directories})
+    endif()
+
+    #setting logging_files
+    if(DEFINED SHARED_UTIL_SRC_FOLDER)
+        set(logging_files ${XLOGGING_C_FILE} ${LOGGING_C_FILE})
+    elseif(DEFINED SHARED_UTIL_FOLDER)
+        set(logging_files ${XLOGGING_C_FILE} ${LOGGING_C_FILE})
+    else()
+        message(WARNING "No Shared Utility folder defined, no logging file compiled in.")
+    endif()
+
+    #setting output type
+    if(WIN32)
+        if(
+            (("${whatIsBuilding}" MATCHES ".*ut.*") AND ${run_unittests}) OR
+            (("${whatIsBuilding}" MATCHES ".*e2e.*") AND ${run_e2e_tests}) OR
+            (("${whatIsBuilding}" MATCHES ".*int.*") AND ${run_int_tests}) OR
+            (("${whatIsBuilding}" MATCHES ".*perf.*") AND ${run_perf_tests})
+        )
+            if (${use_cppunittest})
+                c_windows_tests_add_dll(${whatIsBuilding} ${folder} ${ARGN})
+            endif()
+            c_windows_tests_add_exe(${whatIsBuilding} ${folder} ${ARGN})
+        else()
+            if(
+                (("${whatIsBuilding}" MATCHES ".*e2e.*") AND ("${nuget_e2e_tests}" STREQUAL "ON"))
+            )
+                c_windows_tests_add_exe(${whatIsBuilding}_nuget ${folder} ${ARGN})
+            else()
+                #do nothing
+            endif()
+        endif()
+    else()
+        if(
+            (("${whatIsBuilding}" MATCHES ".*ut.*") AND ${run_unittests}) OR
+            (("${whatIsBuilding}" MATCHES ".*e2e.*") AND ${run_e2e_tests}) OR
+            (("${whatIsBuilding}" MATCHES ".*int.*") AND ${run_int_tests}) OR
+            (("${whatIsBuilding}" MATCHES ".*perf.*") AND ${run_perf_tests})
+        )
+            c_linux_tests_add_exe(${whatIsBuilding} ${folder} ${ARGN})
+        endif()
+    endif()
+endfunction()

--- a/test_projects/CMakeLists.txt
+++ b/test_projects/CMakeLists.txt
@@ -1,0 +1,7 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+add_subdirectory(test_project_ut)
+add_subdirectory(test_project_int)
+add_subdirectory(test_project_e2e)
+add_subdirectory(test_project_perf)

--- a/test_projects/test_project_e2e/CMakeLists.txt
+++ b/test_projects/test_project_e2e/CMakeLists.txt
@@ -1,0 +1,18 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required(VERSION 2.8.11)
+
+set(theseTestsName test_project_e2e)
+
+set(${theseTestsName}_test_files
+    ${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+)
+
+set(${theseTestsName}_h_files
+)
+
+build_c_tests(${theseTestsName} ON "tests/azure_c_build_tools")

--- a/test_projects/test_project_e2e/main.c
+++ b/test_projects/test_project_e2e/main.c
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+int main(void)
+{
+    // this unit does nothing, it is just an empty executable to test generation of test projects
+    return 0;
+}

--- a/test_projects/test_project_e2e/test_project_e2e.c
+++ b/test_projects/test_project_e2e/test_project_e2e.c
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+static int some_variable_1D0ECA11_C7CE_4297_97E4_3A706D23BE6A;

--- a/test_projects/test_project_int/CMakeLists.txt
+++ b/test_projects/test_project_int/CMakeLists.txt
@@ -1,0 +1,18 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required(VERSION 2.8.11)
+
+set(theseTestsName test_project_int)
+
+set(${theseTestsName}_test_files
+    ${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+)
+
+set(${theseTestsName}_h_files
+)
+
+build_c_tests(${theseTestsName} ON "tests/azure_c_build_tools")

--- a/test_projects/test_project_int/main.c
+++ b/test_projects/test_project_int/main.c
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+int main(void)
+{
+    // this unit does nothing, it is just an empty executable to test generation of test projects
+    return 0;
+}

--- a/test_projects/test_project_int/test_project_int.c
+++ b/test_projects/test_project_int/test_project_int.c
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+static int some_variable_1CAAF3FF_7A86_4A14_8D2C_434EF0BA2AB1;

--- a/test_projects/test_project_perf/CMakeLists.txt
+++ b/test_projects/test_project_perf/CMakeLists.txt
@@ -1,0 +1,18 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required(VERSION 2.8.11)
+
+set(theseTestsName test_project_perf)
+
+set(${theseTestsName}_test_files
+    ${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+)
+
+set(${theseTestsName}_h_files
+)
+
+build_c_tests(${theseTestsName} ON "tests/azure_c_build_tools")

--- a/test_projects/test_project_perf/main.c
+++ b/test_projects/test_project_perf/main.c
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+int main(void)
+{
+    // this unit does nothing, it is just an empty executable to test generation of test projects
+    return 0;
+}

--- a/test_projects/test_project_perf/test_project_perf.c
+++ b/test_projects/test_project_perf/test_project_perf.c
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+static int some_variable_526900A4_3F36_48C7_9346_CBE8CC395C09;

--- a/test_projects/test_project_ut/CMakeLists.txt
+++ b/test_projects/test_project_ut/CMakeLists.txt
@@ -1,0 +1,18 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required(VERSION 2.8.11)
+
+set(theseTestsName test_project_ut)
+
+set(${theseTestsName}_test_files
+    ${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+)
+
+set(${theseTestsName}_h_files
+)
+
+build_c_tests(${theseTestsName} ON "tests/azure_c_build_tools")

--- a/test_projects/test_project_ut/main.c
+++ b/test_projects/test_project_ut/main.c
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+int main(void)
+{
+    // this unit does nothing, it is just an empty executable to test generation of test projects
+    return 0;
+}

--- a/test_projects/test_project_ut/test_project_ut.c
+++ b/test_projects/test_project_ut/test_project_ut.c
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+static int some_variable_9C57CF60_3AFB_4E08_9E94_D461587D4CEF;


### PR DESCRIPTION
Add tests cmake functions that allow generating tests projects for unit/int/e2e/perf tests.
This will be propagated to replace the existing functions in all the other submodules (C shared, etc.)

The functions behave in the same way for now as I want the switch to be relatively transparent so the amount of cries across the repos is minimal.