### PR TITLE
Allow forward slash in exclude paths & build via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,4 @@ option(run_perf_tests "set run_int_tests to ON to build performance tests (defau
 
 add_subdirectory(test_build_functions)
 add_subdirectory(test_projects)
+add_subdirectory(traceabilitytool)

--- a/build/devops.yml
+++ b/build/devops.yml
@@ -17,6 +17,9 @@ phases:
       filename: '"c:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"'
       modifyEnvironment: true
 
+  - task: NuGetToolInstaller@0
+    displayName: 'Use NuGet 4.3.0 (required for .NET core assemblies)'
+
   - task: CMake@1
     displayName: 'CMake ..'
     inputs:

--- a/build/devops.yml
+++ b/build/devops.yml
@@ -21,17 +21,17 @@ phases:
     displayName: 'Use NuGet 4.3.0 (required for .NET core assemblies)'
 
   - task: CMake@1
-    displayName: 'CMake ..'
+    displayName: 'CMake .. -G "Visual Studio 15 2017 Win64"'
     inputs:
-      workingDirectory: 'build'
-      cmakeArgs: '..'
+      workingDirectory: 'build_x64'
+      cmakeArgs: '.. -G "Visual Studio 15 2017 Win64"'
 
   - task: VSBuild@1
-    displayName: 'Build solution build\*.sln'
+    displayName: 'Build solution build_x64\*.sln'
     inputs:
-      solution: 'build\*.sln'
-      platform: 'Any CPU'
-      configuration: Release
+      solution: 'build_x64\*.sln'
+      platform: x64
+      configuration: Debug
       maximumCpuCount: true
 
   - task: Npm@1

--- a/build/devops.yml
+++ b/build/devops.yml
@@ -17,15 +17,16 @@ phases:
       filename: '"c:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"'
       modifyEnvironment: true
 
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore'
+  - task: CMake@1
+    displayName: 'CMake ..'
     inputs:
-      restoreSolution: traceabilitytool/traceabilitytool.sln
+      workingDirectory: 'build'
+      cmakeArgs: '..'
 
   - task: VSBuild@1
-    displayName: 'Build solution traceabilitytool/traceabilitytool.sln'
+    displayName: 'Build solution build\*.sln'
     inputs:
-      solution: traceabilitytool/traceabilitytool.sln
+      solution: 'build\*.sln'
       platform: 'Any CPU'
       configuration: Release
       maximumCpuCount: true

--- a/traceabilitytool/CMakeLists.txt
+++ b/traceabilitytool/CMakeLists.txt
@@ -1,0 +1,16 @@
+#Copyright (C) Microsoft Corporation. All rights reserved.
+
+find_program(NUGET nuget)
+if(NOT NUGET)
+    message(FATAL "CMake could not find the nuget command line tool. Please install it!")
+else()
+    add_custom_target(traceabilitytool-nuget-restore
+        COMMAND ${NUGET} restore ${CMAKE_SOURCE_DIR}/traceabilitytool/traceability_tool/packages.config -PackagesDirectory ${CMAKE_SOURCE_DIR}/traceabilitytool/packages -Verbosity detailed
+    )
+endif()
+
+include_external_msproject(
+    traceabilitytool ${CMAKE_SOURCE_DIR}/traceabilitytool/traceability_tool/traceabilitytool.csproj
+    TYPE FAE04EC0-301F-11D3-BF4B-00C04F79EFBC)
+
+add_dependencies(traceabilitytool traceabilitytool-nuget-restore)

--- a/traceabilitytool/traceability_tool/program.cs
+++ b/traceabilitytool/traceability_tool/program.cs
@@ -6,7 +6,9 @@ using System.Windows.Forms;  // Used for Application class
 using System.IO;             // Used for StreamWriter class
 using System.Runtime.InteropServices;  // Used for DllImport
 using System.Diagnostics;    // Used for Process class
-
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TraceabilityTool
 {
@@ -19,7 +21,7 @@ namespace TraceabilityTool
         // Directory to place reports into.
         public static string outputDir = "";
         // directories to exclude
-        public static string[] exclusionDirs = null;
+        public static IList<string> exclusionDirs = new List<string>();
         // Exit program with code 0 if correct parameters were supplied.
         public static int exitCode = 0;
 
@@ -63,11 +65,12 @@ namespace TraceabilityTool
         {
             bool inputDirValid = false;
             bool outputDirValid = false;
-            bool exclusionDirsValid = false;
             bool buildCheck = false;
             bool optionGUI = false;
             // Command line interface can be enabled as a command line option
             bool consoleEnabled = false;
+
+            exclusionDirs = new List<string>();
 
             if (args.Length > 0)
             {
@@ -109,14 +112,17 @@ namespace TraceabilityTool
                     if (args[i].Equals("-e", StringComparison.OrdinalIgnoreCase) && (i < args.Length - 1))
                     {
                         string[] dirs = args[i + 1].Split(';');
-                        exclusionDirsValid = true;
                         foreach (string d in dirs)
                         {
-                            exclusionDirsValid &= Directory.Exists(d);
-                        }
-                        if (exclusionDirsValid)
-                        {
-                            exclusionDirs = dirs;
+                            string backSlashDir = d.Replace("/", "\\");
+                            if (!Directory.Exists(backSlashDir))
+                            {
+                                Console.WriteLine($"Invalid exclusion directory specified: {d}");
+                            }
+                            else
+                            {
+                                exclusionDirs.Add(backSlashDir);
+                            }
                         }
                     }
                 }
@@ -165,7 +171,7 @@ namespace TraceabilityTool
                 else
                 {
                     // The minimum required parameters were correctly specified.  Run the reports in CLI mode
-                    exitCode = ReportGenerator.GenerateReport(inputDir, outputDir, exclusionDirs, null);
+                    exitCode = ReportGenerator.GenerateReport(inputDir, outputDir, exclusionDirs.ToArray(), null);
                     Console.WriteLine();
                     if (outputDirValid)
                     {

--- a/traceabilitytool/traceability_tool/traceabilitytool.csproj
+++ b/traceabilitytool/traceability_tool/traceabilitytool.csproj
@@ -27,6 +27,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
- Allow forward slash in exclude paths
- Update build yml to run cmake and build
- Add targets for traceability tool and the nuget restore for it