### PR TITLE
Add support to srs extension for tagging multiple lines

### DIFF
--- a/srs_extension/README.md
+++ b/srs_extension/README.md
@@ -34,7 +34,7 @@ To insert a new requirement tag:
 
 All requirement tags use the following syntax: `SRS_SOMESTRING_<DEVID>_<REQID>`
 
-You may also insert requirement tags for the currently selected text b y pressing `Alt+F9`. This will:
+You may also insert requirement tags for the currently selected text by pressing `Alt+F9`. This will:
  - Tag all non-empty (white space only) lines
  - Preserve unordered list markdown (i.e. skip over combinations of `-` and space)
 

--- a/srs_extension/README.md
+++ b/srs_extension/README.md
@@ -34,6 +34,10 @@ To insert a new requirement tag:
 
 All requirement tags use the following syntax: `SRS_SOMESTRING_<DEVID>_<REQID>`
 
+You may also insert requirement tags for the currently selected text b y pressing `Alt+F9`. This will:
+ - Tag all non-empty (white space only) lines
+ - Preserve unordered list markdown (i.e. skip over combinations of `-` and space)
+
 (Right now the requirement tag format is hardcoded.)
 
 There are a couple more things you can do, by bringing up the command pane (by pressing F1):

--- a/srs_extension/extension.js
+++ b/srs_extension/extension.js
@@ -18,26 +18,32 @@ function activate(context) {
         if(id && id.trim().length > 0) {
             devId = id;
             saveDevId(id);
+            return true;
         }
+        return false;
     };
 
     var setReqPrefix = function (prefix) {
         if(!!prefix) {
             if(prefix === ADD_NEW_PREFIX) {
-                vscode.window.showInputBox({
+                return vscode.window.showInputBox({
                     placeHolder: 'New requirement prefix',
                     prompt: 'Enter the new requirement prefix to use'
                 })
                 .then(function(newPrefix) {
                     if(!!newPrefix) {
                         reqPrefix = newPrefix;
+                        return true;
                     }
+                    return false;
                 });
             }
             else {
                 reqPrefix = prefix;
+                return true;
             }
         }
+        return false;
     };
     
     var askDevId = function () {
@@ -83,7 +89,7 @@ function activate(context) {
             var editor = vscode.window.activeTextEditor;
             var startSnippet = '**' + reqTag + ': [** ';
             var endSnippet = ' **]**';
-            editor.edit(function (e) {
+            return editor.edit(function (e) {
                 // insert start snippet
                 e.insert(editor.selection.start, startSnippet);
             }).then(function(status) {
@@ -101,7 +107,10 @@ function activate(context) {
                     var pos = editor.selection.end.translate(0, -1 * endSnippet.length);
                     editor.selection = new vscode.Selection(pos, pos);
                 }
+                return status;
             });
+        } else {
+            return editor.edit(function (e) {}).then(function(status) { return status; });
         }
     };
 
@@ -121,20 +130,16 @@ function activate(context) {
             var stopLine = editor.selection.end.line;
             while (positionIterator.line <= stopLine) {
                 var line = document.lineAt(positionIterator);
-                console.log("checking line: " + line.text);
                 // Attempt to add requirement to each line
                 if (!line.isEmptyOrWhitespace) {
                     // Skip markdown list and white space around it
                     var startOffset = line.firstNonWhitespaceCharacterIndex;
                     while (line.text.charAt(startOffset) == '-' || line.text.charAt(startOffset) == ' ') {
                         startOffset++;
-                        console.log("skipping over - or ' '");
                     }
                     if (line.text.charAt(startOffset) != '\n' && line.text.charAt(startOffset) != '\r') {
                         var lineStart = positionIterator.translate(0, startOffset);
                         rangesToEdit.push(lineStart);
-                    } else {
-                        console.log("line was empty after skipping characters")
                     }
                 }
                 positionIterator = positionIterator.with(positionIterator.line + 1, 0);
@@ -145,19 +150,19 @@ function activate(context) {
             rangesToEdit.forEach(function (value, index, array){
                 var doInsertStart = function (e) {
                     // insert start snippet
-                    console.log("insert start at " + value.line + ", " + value.character );
                     var startSnippet = '**' + nextReqTag + ': [** ';
                     nextReqTag = reqParser.getNextReq(nextReqTag, reqPrefix, devId);
                     e.insert(value, startSnippet);
                 };
 
                 var doInsertEnd = function (e) {
+                    // recompute line end (after inserting start) and insert end
                     var line = document.lineAt(value);
                     var lineEnd = value.with(value.line, line.text.length);
-                    console.log("insert end at " + lineEnd.line + ", " + lineEnd.character );
                     e.insert(lineEnd, endSnippet);
                 };
                 
+                // Insert start
                 if (task == null) {
                     task = editor.edit(doInsertStart);
                 } else {
@@ -168,43 +173,52 @@ function activate(context) {
                         return status;
                     });
                 }
+
+                // Insert end
                 task = task.then(function(status) {
                     if (status) {
-                        // insert end snippet
                         return editor.edit(doInsertEnd);
                     }
                     return status;
                 });
             });
+            
+            if (task == null) {
+                return editor.edit(function (e) {}).then(function(status) { return status; });
+            } else {
+                return task.then(function(status) { return status; });
+            }
+        } else {
+            return editor.edit(function (e) {}).then(function(status) { return status; });
         }
     };
 
     var insertReqCommand = vscode.commands.registerCommand('extension.insertReqCommand', function () {
         if (devId === "") {
-            askDevId().then(setDevId)
+            return askDevId().then(setDevId)
                       .then(lookupReqPrefix)
                       .then(insertReqTag);
         } else {
             var prefixPromise = lookupReqPrefix();
             if (prefixPromise) {
-                prefixPromise.then(insertReqTag);
+                return prefixPromise.then(insertReqTag);
             } else {
-                insertReqTag();
+                return insertReqTag();
             }
         }
     });
 
     var insertReqsCommand = vscode.commands.registerCommand('extension.insertReqsCommand', function () {
         if (devId === "") {
-            askDevId().then(setDevId)
+            return askDevId().then(setDevId)
                       .then(lookupReqPrefix)
                       .then(insertReqTags);
         } else {
             var prefixPromise = lookupReqPrefix();
             if (prefixPromise) {
-                prefixPromise.then(insertReqTags);
+                return prefixPromise.then(insertReqTags);
             } else {
-                insertReqTags();
+                return insertReqTags();
             }
         }
     });
@@ -221,10 +235,22 @@ function activate(context) {
                      .then(setReqPrefix);
     });
 
+    // Test hook
+    var forceSetDevIdCommand = vscode.commands.registerCommand('extension.forceSetDevId', function (id) {
+        setDevId(id);
+    });
+    var forceSetReqPrefixCommand = vscode.commands.registerCommand('extension.forceSetReqPrefix', function (prefix) {
+        setReqPrefix(prefix);
+    });
+
     context.subscriptions.push(insertReqCommand);
     context.subscriptions.push(insertReqsCommand);
     context.subscriptions.push(changeDevIdCommand);
     context.subscriptions.push(changeReqPrefixCommand);
+
+    // Expose commands for test that don't need UI
+    context.subscriptions.push(forceSetDevIdCommand);
+    context.subscriptions.push(forceSetReqPrefixCommand);
 }
 
 // from: http://stackoverflow.com/a/9081436
@@ -236,11 +262,11 @@ function saveDevId(devid) {
     var settingsPath = path.join(getUserHome(), '.reqdocs');
     var settings = {};
     if(FS.existsSync(settingsPath)) {
-        settings = FS.readFileSync(settingsPath, {
+        var settingString = FS.readFileSync(settingsPath, {
             encoding: 'utf8'
         });
-        if(settings) {
-            settings = JSON.parse(settings);
+        if(settingString) {
+            settings = JSON.parse(settingString);
         }
     }
     settings.devid = devid;

--- a/srs_extension/package.json
+++ b/srs_extension/package.json
@@ -2,7 +2,7 @@
     "name": "azure-req-doc-ext",
     "displayName": "Azure SRS Requirement Documents Extension",
     "description": "Generate requirement tags for SRS requirement documents",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "publisher": "microsoft",
     "repository": "https://github.com/Azure/azure-c-build-tools/tree/master/srs_extension",
     "engines": {
@@ -34,6 +34,10 @@
             {
                 "command": "extension.insertReqCommand",
                 "key": "Alt+F8"
+            },
+            {
+                "command": "extension.insertReqsCommand",
+                "key": "Alt+F9"
             }
         ]
     },

--- a/srs_extension/test/memfs.js
+++ b/srs_extension/test/memfs.js
@@ -1,0 +1,178 @@
+// Source is from the official test sample (compiled typescript to js)
+// https://github.com/microsoft/vscode/blob/master/extensions/vscode-api-tests/src/memfs.ts
+
+"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
+const vscode = require("vscode");
+class File {
+    constructor(name) {
+        this.type = vscode.FileType.File;
+        this.ctime = Date.now();
+        this.mtime = Date.now();
+        this.size = 0;
+        this.name = name;
+    }
+}
+exports.File = File;
+class Directory {
+    constructor(name) {
+        this.type = vscode.FileType.Directory;
+        this.ctime = Date.now();
+        this.mtime = Date.now();
+        this.size = 0;
+        this.name = name;
+        this.entries = new Map();
+    }
+}
+exports.Directory = Directory;
+class MemFS {
+    constructor() {
+        this.root = new Directory('');
+        this.scheme = 'memfs';
+        // --- manage file events
+        this._emitter = new vscode.EventEmitter();
+        this._bufferedEvents = [];
+        this.onDidChangeFile = this._emitter.event;
+    }
+    // --- manage file metadata
+    stat(uri) {
+        return this._lookup(uri, false);
+    }
+    readDirectory(uri) {
+        const entry = this._lookupAsDirectory(uri, false);
+        let result = [];
+        for (const [name, child] of entry.entries) {
+            result.push([name, child.type]);
+        }
+        return result;
+    }
+    // --- manage file contents
+    readFile(uri) {
+        const data = this._lookupAsFile(uri, false).data;
+        if (data) {
+            return data;
+        }
+        throw vscode.FileSystemError.FileNotFound();
+    }
+    writeFile(uri, content, options) {
+        let basename = path.posix.basename(uri.path);
+        let parent = this._lookupParentDirectory(uri);
+        let entry = parent.entries.get(basename);
+        if (entry instanceof Directory) {
+            throw vscode.FileSystemError.FileIsADirectory(uri);
+        }
+        if (!entry && !options.create) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        if (entry && options.create && !options.overwrite) {
+            throw vscode.FileSystemError.FileExists(uri);
+        }
+        if (!entry) {
+            entry = new File(basename);
+            parent.entries.set(basename, entry);
+            this._fireSoon({ type: vscode.FileChangeType.Created, uri });
+        }
+        entry.mtime = Date.now();
+        entry.size = content.byteLength;
+        entry.data = content;
+        this._fireSoon({ type: vscode.FileChangeType.Changed, uri });
+    }
+    // --- manage files/folders
+    rename(oldUri, newUri, options) {
+        if (!options.overwrite && this._lookup(newUri, true)) {
+            throw vscode.FileSystemError.FileExists(newUri);
+        }
+        let entry = this._lookup(oldUri, false);
+        let oldParent = this._lookupParentDirectory(oldUri);
+        let newParent = this._lookupParentDirectory(newUri);
+        let newName = path.posix.basename(newUri.path);
+        oldParent.entries.delete(entry.name);
+        entry.name = newName;
+        newParent.entries.set(newName, entry);
+        this._fireSoon({ type: vscode.FileChangeType.Deleted, uri: oldUri }, { type: vscode.FileChangeType.Created, uri: newUri });
+    }
+    delete(uri) {
+        let dirname = uri.with({ path: path.posix.dirname(uri.path) });
+        let basename = path.posix.basename(uri.path);
+        let parent = this._lookupAsDirectory(dirname, false);
+        if (!parent.entries.has(basename)) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        parent.entries.delete(basename);
+        parent.mtime = Date.now();
+        parent.size -= 1;
+        this._fireSoon({ type: vscode.FileChangeType.Changed, uri: dirname }, { uri, type: vscode.FileChangeType.Deleted });
+    }
+    createDirectory(uri) {
+        let basename = path.posix.basename(uri.path);
+        let dirname = uri.with({ path: path.posix.dirname(uri.path) });
+        let parent = this._lookupAsDirectory(dirname, false);
+        let entry = new Directory(basename);
+        parent.entries.set(entry.name, entry);
+        parent.mtime = Date.now();
+        parent.size += 1;
+        this._fireSoon({ type: vscode.FileChangeType.Changed, uri: dirname }, { type: vscode.FileChangeType.Created, uri });
+    }
+    _lookup(uri, silent) {
+        let parts = uri.path.split('/');
+        let entry = this.root;
+        for (const part of parts) {
+            if (!part) {
+                continue;
+            }
+            let child;
+            if (entry instanceof Directory) {
+                child = entry.entries.get(part);
+            }
+            if (!child) {
+                if (!silent) {
+                    throw vscode.FileSystemError.FileNotFound(uri);
+                }
+                else {
+                    return undefined;
+                }
+            }
+            entry = child;
+        }
+        return entry;
+    }
+    _lookupAsDirectory(uri, silent) {
+        let entry = this._lookup(uri, silent);
+        if (entry instanceof Directory) {
+            return entry;
+        }
+        throw vscode.FileSystemError.FileNotADirectory(uri);
+    }
+    _lookupAsFile(uri, silent) {
+        let entry = this._lookup(uri, silent);
+        if (entry instanceof File) {
+            return entry;
+        }
+        throw vscode.FileSystemError.FileIsADirectory(uri);
+    }
+    _lookupParentDirectory(uri) {
+        const dirname = uri.with({ path: path.posix.dirname(uri.path) });
+        return this._lookupAsDirectory(dirname, false);
+    }
+    watch(_resource) {
+        // ignore, fires for all changes...
+        return new vscode.Disposable(() => { });
+    }
+    _fireSoon(...events) {
+        this._bufferedEvents.push(...events);
+        if (this._fireSoonHandle) {
+            clearTimeout(this._fireSoonHandle);
+        }
+        this._fireSoonHandle = setTimeout(() => {
+            this._emitter.fire(this._bufferedEvents);
+            this._bufferedEvents.length = 0;
+        }, 5);
+    }
+}
+exports.MemFS = MemFS;
+//# sourceMappingURL=memfs.js.map

--- a/srs_extension/test/suite/editor.int.test.js
+++ b/srs_extension/test/suite/editor.int.test.js
@@ -1,0 +1,347 @@
+const assert = require('assert');
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+const vscode = require('vscode');
+const MemFS = require('../memfs');
+
+const extension = require('../../extension');
+
+// Test code based on https://github.com/microsoft/vscode/tree/master/extensions/vscode-api-tests/src/singlefolder-tests
+
+function rndName() {
+    return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10);
+}
+
+const testFs = new MemFS.MemFS();
+vscode.workspace.registerFileSystemProvider(testFs.scheme, testFs);
+
+async function createRandomFile(contents = '', dir = undefined, ext = '') {
+    var fakeFile;
+    if (dir) {
+        assert.equal(dir.scheme, testFs.scheme);
+        fakeFile = dir.with({ path: dir.path + '/' + rndName() + ext });
+    } else {
+        fakeFile = vscode.Uri.parse(`${testFs.scheme}:/${rndName() + ext}`);
+    }
+    await testFs.writeFile(fakeFile, Buffer.from(contents), { create: true, overwrite: true });
+    return fakeFile;
+}
+
+async function deleteFile(file) {
+    try {
+        await testFs.delete(file);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function closeAllEditors() {
+    return vscode.commands.executeCommand('workbench.action.closeAllEditors');
+}
+
+
+const sampleFileBefore = `
+# A File header
+
+This is my spec:
+   
+do something
+
+do something else
+
+do a third thing
+`;
+
+const sampleFileAfterOneSpec = `
+# A File header
+
+This is my spec:
+   
+**SRS_MY_PREFIX_08_001: [** do something **]**
+
+do something else
+
+do a third thing
+`;
+
+const sampleFileAfter = `
+# A File header
+
+This is my spec:
+   
+**SRS_MY_PREFIX_08_001: [** do something **]**
+
+**SRS_MY_PREFIX_08_002: [** do something else **]**
+
+**SRS_MY_PREFIX_08_003: [** do a third thing **]**
+`;
+
+const sampleFileWithExistingBefore = `
+# A File header
+
+**SRS_MY_PREFIX_08_142: [** This is my spec: **]**
+
+do something
+
+do something else
+
+do a third thing
+`;
+
+const sampleFileWithExistingAfterOneSpec = `
+# A File header
+
+**SRS_MY_PREFIX_08_142: [** This is my spec: **]**
+
+do something
+
+**SRS_MY_PREFIX_08_143: [** do something else **]**
+
+do a third thing
+`;
+
+const sampleFileWithExistingAfter = `
+# A File header
+
+**SRS_MY_PREFIX_08_142: [** This is my spec: **]**
+
+**SRS_MY_PREFIX_08_143: [** do something **]**
+
+**SRS_MY_PREFIX_08_144: [** do something else **]**
+
+**SRS_MY_PREFIX_08_145: [** do a third thing **]**
+`;
+
+const otherSampleFile = `## hello world
+
+
+This file has white space
+
+
+
+done.`;
+
+const sampleFileBeforeWithLists = `
+# A File header
+
+Do many things:
+   
+ - do something
+
+ - do something else
+
+   - sublist item
+
+Last one
+`;
+
+const sampleFileAfterWithLists = `
+# A File header
+
+**SRS_MY_PREFIX_08_001: [** Do many things: **]**
+   
+ - **SRS_MY_PREFIX_08_002: [** do something **]**
+
+ - **SRS_MY_PREFIX_08_003: [** do something else **]**
+
+   - **SRS_MY_PREFIX_08_004: [** sublist item **]**
+
+**SRS_MY_PREFIX_08_005: [** Last one **]**
+`;
+
+suite('Editor Int Test Suite', () => {
+    vscode.window.showInformationMessage('Start editor int tests.');
+
+    teardown(closeAllEditors);
+
+    function withRandomFileEditor(initialContents, run) {
+        return createRandomFile(initialContents, undefined, '.md').then(file => {
+            return vscode.workspace.openTextDocument(file).then(doc => {
+                return vscode.window.showTextDocument(doc).then((editor) => {
+                    return run(editor, doc).then(_ => {
+                        if (doc.isDirty) {
+                            return doc.save().then(saved => {
+                                assert.ok(saved);
+                                assert.ok(!doc.isDirty);
+                                return deleteFile(file);
+                            });
+                        } else {
+                            return deleteFile(file);
+                        }
+                    });
+                });
+            });
+        });
+    }
+
+    test('Tag one requirement', (done) => {
+        withRandomFileEditor(sampleFileBefore, (editor, doc) => {
+            editor.selection = new vscode.Selection(
+                new vscode.Position(5, 0),
+                new vscode.Position(5, 12)
+            );
+
+            return vscode.commands.executeCommand("extension.forceSetDevId", "8").then(_ => {
+                return vscode.commands.executeCommand("extension.forceSetReqPrefix", "SRS_MY_PREFIX_").then(_ => {
+                    return vscode.commands.executeCommand("extension.insertReqCommand").then(status => {
+                        assert.ok(status);
+                        assert.equal(doc.getText(), sampleFileAfterOneSpec);
+                        done();
+                    });
+                });
+            });
+        })
+        .catch(err => {
+            done(err);
+        });
+    });
+
+    test('Tag one requirement with existing requirement', (done) => {
+        withRandomFileEditor(sampleFileWithExistingBefore, (editor, doc) => {
+            editor.selection = new vscode.Selection(
+                new vscode.Position(7, 0),
+                new vscode.Position(7, 17)
+            );
+
+            return vscode.commands.executeCommand("extension.forceSetDevId", "8").then(_ => {
+                return vscode.commands.executeCommand("extension.forceSetReqPrefix", "SRS_MY_PREFIX_").then(_ => {
+                    return vscode.commands.executeCommand("extension.insertReqCommand").then(status => {
+                        assert.ok(status);
+                        assert.equal(doc.getText(), sampleFileWithExistingAfterOneSpec);
+                        done();
+                    });
+                });
+            });
+        })
+        .catch(err => {
+            done(err);
+        });
+    });
+
+    test('Tag three requirements', (done) => {
+        withRandomFileEditor(sampleFileBefore, (editor, doc) => {
+            editor.selection = new vscode.Selection(
+                new vscode.Position(5, 0),
+                new vscode.Position(5, 12)
+            );
+
+            return vscode.commands.executeCommand("extension.forceSetDevId", "8").then(_ => {
+                return vscode.commands.executeCommand("extension.forceSetReqPrefix", "SRS_MY_PREFIX_").then(_ => {
+                    return vscode.commands.executeCommand("extension.insertReqCommand").then(status => {
+                        assert.ok(status);
+                        editor.selection = new vscode.Selection(
+                            new vscode.Position(7, 0),
+                            new vscode.Position(7, 17)
+                        );
+                        return vscode.commands.executeCommand("extension.insertReqCommand").then(status => {
+                            assert.ok(status);
+                            editor.selection = new vscode.Selection(
+                                new vscode.Position(9, 0),
+                                new vscode.Position(9, 16)
+                            );
+                            return vscode.commands.executeCommand("extension.insertReqCommand").then(status => {
+                                assert.ok(status);
+                                assert.equal(doc.getText(), sampleFileAfter);
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+        })
+        .catch(err => {
+            done(err);
+        });
+    });
+
+    test('Tag three requirements with one command', (done) => {
+        withRandomFileEditor(sampleFileBefore, (editor, doc) => {
+            editor.selection = new vscode.Selection(
+                new vscode.Position(5, 0),
+                new vscode.Position(9, 16)
+            );
+
+            return vscode.commands.executeCommand("extension.forceSetDevId", "8").then(_ => {
+                return vscode.commands.executeCommand("extension.forceSetReqPrefix", "SRS_MY_PREFIX_").then(_ => {
+                    return vscode.commands.executeCommand("extension.insertReqsCommand").then(status => {
+                        assert.ok(status);
+                        assert.equal(doc.getText(), sampleFileAfter);
+                        done();
+                    });
+                });
+            });
+        })
+        .catch(err => {
+            done(err);
+        });
+    });
+
+    test('Tag multiple does nothing when selection is whitespace', (done) => {
+        withRandomFileEditor(otherSampleFile, (editor, doc) => {
+            editor.selection = new vscode.Selection(
+                new vscode.Position(4, 0),
+                new vscode.Position(6, 0)
+            );
+
+            return vscode.commands.executeCommand("extension.forceSetDevId", "8").then(_ => {
+                return vscode.commands.executeCommand("extension.forceSetReqPrefix", "SRS_MY_PREFIX_").then(_ => {
+                    return vscode.commands.executeCommand("extension.insertReqsCommand").then(status => {
+                        assert.ok(status);
+                        assert.equal(doc.getText(), otherSampleFile);
+                        done();
+                    });
+                });
+            });
+        })
+        .catch(err => {
+            done(err);
+        });
+    });
+
+    test('Tag multiple requirements with one command with existing', (done) => {
+        withRandomFileEditor(sampleFileWithExistingBefore, (editor, doc) => {
+            editor.selection = new vscode.Selection(
+                new vscode.Position(5, 0),
+                new vscode.Position(9, 16)
+            );
+
+            return vscode.commands.executeCommand("extension.forceSetDevId", "8").then(_ => {
+                return vscode.commands.executeCommand("extension.forceSetReqPrefix", "SRS_MY_PREFIX_").then(_ => {
+                    return vscode.commands.executeCommand("extension.insertReqsCommand").then(status => {
+                        assert.ok(status);
+                        assert.equal(doc.getText(), sampleFileWithExistingAfter);
+                        done();
+                    });
+                });
+            });
+        })
+        .catch(err => {
+            done(err);
+        });
+    });
+
+    test('Tag multiple requirements with markdown lists', (done) => {
+        withRandomFileEditor(sampleFileBeforeWithLists, (editor, doc) => {
+            editor.selection = new vscode.Selection(
+                new vscode.Position(3, 0),
+                new vscode.Position(12, 0)
+            );
+
+            return vscode.commands.executeCommand("extension.forceSetDevId", "8").then(_ => {
+                return vscode.commands.executeCommand("extension.forceSetReqPrefix", "SRS_MY_PREFIX_").then(_ => {
+                    return vscode.commands.executeCommand("extension.insertReqsCommand").then(status => {
+                        assert.ok(status);
+                        assert.equal(doc.getText(), sampleFileAfterWithLists);
+                        done();
+                    });
+                });
+            });
+        })
+        .catch(err => {
+            done(err);
+        });
+    });
+
+});

--- a/srs_extension/test/suite/index.js
+++ b/srs_extension/test/suite/index.js
@@ -5,7 +5,8 @@ const glob = require('glob');
 function run() {
     // Create the mocha test
     const mocha = new Mocha({
-        ui: 'tdd'
+        ui: 'tdd',
+        timeout: 600000
     });
     // Use any mocha API
     mocha.useColors(true);


### PR DESCRIPTION
Adds command to SRS extension with alt-F9 to tag all lines that are selected (preserving mark-down lists, but otherwise just tags everything as-is). Version 0.0.8