### PR TITLE
Disable warning 4200 for the C compiler on MSC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ option(run_e2e_tests "set run_e2e_tests to ON to build e2e tests (default is OFF
 option(run_int_tests "set run_int_tests to ON to build integration tests (default is OFF)." OFF)
 option(run_perf_tests "set run_int_tests to ON to build performance tests (default is OFF)." OFF)
 
+if(WIN32)
+    # warning C4200: nonstandard extension used: zero-sized array in struct/union : looks very standard in C99 and it is called flexible array. Documentation-wise is a flexible array, but called "unsized" in Microsoft's docs
+    # https://msdn.microsoft.com/en-us/library/b6fae073.aspx
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4200")
+endif()
+
 add_subdirectory(test_build_functions)
 add_subdirectory(test_projects)
 if(WIN32)


### PR DESCRIPTION
Disable warning 4200 for the C compiler on MSC